### PR TITLE
feat: Add taproot assets support in sveltekit-payments-component app

### DIFF
--- a/apps/payments/sveltekit-payments-component/app/package.json
+++ b/apps/payments/sveltekit-payments-component/app/package.json
@@ -30,7 +30,7 @@
 		"typescript": "^5.0.0",
 		"typescript-eslint": "^8.20.0",
 		"vite": "^6.2.6",
-		"voltage-payments-component": "^0.1.3"
+		"voltage-payments-component": "^0.2.0"
 	},
 	"packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
This simply bumps the voltage-payments-component version to 0.2.0 which adds taproot asset support.